### PR TITLE
Do not require google project configuration

### DIFF
--- a/example.repo
+++ b/example.repo
@@ -12,4 +12,3 @@ enabled=1
 ; Optional config flags, set these if you credentials can not be auto retrieved
 ; using the Google Application Default Credentials pipeline:
 ;google_application_credentials=/path-to-creds/credentials.json
-;google_project_id=google-project-name

--- a/gsiam.py
+++ b/gsiam.py
@@ -25,7 +25,6 @@ OPTIONAL_ATTRIBUTES = ['priority', 'base_persistdir', 'metadata_expire',
 UNSUPPORTED_ATTRIBUTES = ['mirrorlist']
 
 def config_hook(conduit):
-  yum.config.RepoConf.google_project_id = yum.config.Option()
   yum.config.RepoConf.google_application_credentials = yum.config.Option()
   yum.config.RepoConf.baseurl = yum.config.UrlListOption(
     schemes=('http', 'https', 's3', 'ftp', 'file', URL_SCHEME.strip(':/'))
@@ -83,11 +82,6 @@ class GCSRepository(YumRepository):
 
     if repo.google_application_credentials:
       os.environ[environment_vars.CREDENTIALS] = repo.google_application_credentials
-    if repo.google_project_id:
-      os.environ[environment_vars.PROJECT] = repo.google_project_id
-
-    if environment_vars.PROJECT in os.environ:
-      self.project_id = os.environ[environment_vars.PROJECT]
     
     self.bucket = bucket
     self.base_path = path
@@ -130,13 +124,13 @@ class GCSRepository(YumRepository):
   @property
   def grab(self):
     if not self.grabber:
-      self.grabber = GCSGrabber(self.bucket, self.base_path, self.project_id)
+      self.grabber = GCSGrabber(self.bucket, self.base_path)
     return self.grabber
 
 
 class GCSGrabber(object):
 
-  def __init__(self, bucket, path, project):
+  def __init__(self, bucket, path):
     self.client = storage.Client()
     self.bucket = self.client.get_bucket(bucket)
     self.base_path = path

--- a/gsiam.py
+++ b/gsiam.py
@@ -86,7 +86,9 @@ class GCSRepository(YumRepository):
     if repo.google_project_id:
       os.environ[environment_vars.PROJECT] = repo.google_project_id
 
-    self.project_id = os.environ[environment_vars.PROJECT]
+    if environment_vars.PROJECT in os.environ:
+      self.project_id = os.environ[environment_vars.PROJECT]
+    
     self.bucket = bucket
     self.base_path = path
     self.name = repo.name


### PR DESCRIPTION
With an example repo config:

```
[my-repo]
name=my-repo
baseurl=gs://my-bucket/my-repo
gpgcheck=0
enabled=1
```

And with yum-gs-iam running on an instance with a service account which has access to the GCS bucket I was getting the error:
```
  File "/usr/lib/yum-plugins/gsiam.py", line 101, in __init__
    if os.environ[environment_vars.PROJECT]:
  File "/usr/lib64/python2.7/UserDict.py", line 23, in __getitem__
    raise KeyError(key)
KeyError: 'GOOGLE_CLOUD_PROJECT'
```

Based on reading the code, it seems as if it always attempts to set the project, even if it was not configured in the repo config, and therefore not set as an environment variable, hence the error.

Also, it appears the project ID is never actually used for anything so seems pointless.

This PR just removes the project ID setting entirely since it doesn't seem to be needed. Let me know if I've misunderstood something.