### PR TITLE
Fix #3 w/ CentOS 7.7+ compatibility for gsiam.py

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
 NAME=yum-plugin-gs-iam
-VERSION=1.0.0
+VERSION=1.1.0


### PR DESCRIPTION
Python functions that Yum expects in plugins changed somewhere between
CentOS 7.4 and 7.7, and on 7.7, Yum is unable to use `gsiam` to parse
`gs://` URLs:

```
[root@f5645f8162d5 /]# yum repolist
Loaded plugins: fastestmirror, gsiam, ovl
Loading mirror speeds from cached hostfile
YumRepo Error: All mirror URLs are not using ftp, http[s] or file.
 Eg. gs://example-bucket/path-to-repo/
```

This patch maintains CentOS 7.4 compatibility and adds CentOS 7.7 and
onward compatibility, as well.