### PR TITLE
Fix Python string formatting for PluginYumExit

### DIFF
--- a/gsiam.py
+++ b/gsiam.py
@@ -33,8 +33,7 @@ def config_hook(conduit):
 
 def check_base_url(baseurl):
   if len(baseurl) != 1:
-    raise yum.plugins.PluginYumExit("Only one base url supported %",
-        baseurl)
+    raise yum.plugins.PluginYumExit("Only one base URL supported; got %s" % baseurl)
 
 
 def parse_url(url):


### PR DESCRIPTION
Repro setup:

```
>>> import yum.plugins
>>> baseurl = ["one", "two"]
```

Before:

```
>>> check_base_url(baseurl)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 3, in check_base_url
yum.plugins.PluginYumExit: Only one base url supported %
```

After:

```
>>> check_base_url(baseurl)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 3, in check_base_url
yum.plugins.PluginYumExit: Only one base URL supported; got ['one', 'two']
```